### PR TITLE
[WIP] feat: 日本語入力で全体が再レンダリングするのを抑止

### DIFF
--- a/src/component/contents/DraftEditorTextNode.react.js
+++ b/src/component/contents/DraftEditorTextNode.react.js
@@ -25,7 +25,7 @@ const useNewlineChar = UserAgent.isBrowser('IE <= 11');
  * Check whether the node should be considered a newline.
  */
 function isNewline(node: Element): boolean {
-  return useNewlineChar ? node.textContent === '\n' : node.tagName === 'BR';
+  return node.childNodes.length === 1 && node.childNodes[0].nodeName === 'BR';
 }
 
 /**

--- a/src/component/contents/DraftEditorTextNode.react.js
+++ b/src/component/contents/DraftEditorTextNode.react.js
@@ -39,22 +39,15 @@ function isNewline(node: Element): boolean {
  * See http://jsfiddle.net/9khdavod/ for the failure case, and
  * http://jsfiddle.net/7pg143f7/ for the fixed case.
  */
+// TALTO: 変換確定の再レンダリングを抑止するための措置
 const NEWLINE_A = ref =>
-  useNewlineChar ? (
-    <span key="A" data-text="true" ref={ref}>
-      {'\n'}
-    </span>
-  ) : (
-    <br key="A" data-text="true" ref={ref} />
+  (
+    <span key="A" data-text="true" ref={ref}><br /></span>
   );
 
 const NEWLINE_B = ref =>
-  useNewlineChar ? (
-    <span key="B" data-text="true" ref={ref}>
-      {'\n'}
-    </span>
-  ) : (
-    <br key="B" data-text="true" ref={ref} />
+  (
+    <span key="B" data-text="true" ref={ref}><br /></span>
   );
 
 type Props = {children: string, ...};

--- a/src/component/contents/DraftEditorTextNode.react.js
+++ b/src/component/contents/DraftEditorTextNode.react.js
@@ -25,7 +25,7 @@ const useNewlineChar = UserAgent.isBrowser('IE <= 11');
  * Check whether the node should be considered a newline.
  */
 function isNewline(node: Element): boolean {
-  return node.childNodes.length === 1 && node.childNodes[0].nodeName === 'BR';
+  return useNewlineChar ? node.textContent === '\n' : node.node.childNodes.length === 1 && node.childNodes[0].nodeName === 'BR';
 }
 
 /**
@@ -41,12 +41,20 @@ function isNewline(node: Element): boolean {
  */
 // TALTO: 変換確定の再レンダリングを抑止するための措置
 const NEWLINE_A = ref =>
-  (
+  useNewlineChar ? (
+    <span key="A" data-text="true" ref={ref}>
+      {'\n'}
+    </span>
+  ) : (
     <span key="A" data-text="true" ref={ref}><br /></span>
   );
 
 const NEWLINE_B = ref =>
-  (
+  useNewlineChar ? (
+    <span key="B" data-text="true" ref={ref}>
+      {'\n'}
+    </span>
+  ) : (
     <span key="B" data-text="true" ref={ref}><br /></span>
   );
 

--- a/src/component/contents/DraftEditorTextNode.react.js
+++ b/src/component/contents/DraftEditorTextNode.react.js
@@ -25,7 +25,7 @@ const useNewlineChar = UserAgent.isBrowser('IE <= 11');
  * Check whether the node should be considered a newline.
  */
 function isNewline(node: Element): boolean {
-  return useNewlineChar ? node.textContent === '\n' : node.node.childNodes.length === 1 && node.childNodes[0].nodeName === 'BR';
+  return useNewlineChar ? node.textContent === '\n' : node.childNodes.length === 1 && node.childNodes[0].nodeName === 'BR';
 }
 
 /**

--- a/src/component/handlers/composition/DraftEditorCompositionHandler.js
+++ b/src/component/handlers/composition/DraftEditorCompositionHandler.js
@@ -226,7 +226,7 @@ const DraftEditorCompositionHandler = {
     );
     const compositionEndSelectionState = documentSelection.selectionState;
 
-    editor.restoreEditorDOM();
+    // editor.restoreEditorDOM(); // TALTO: leafの初めに入力しても描画できるようになったので、全体の再レンダリングは不要になった
 
     // See:
     // - https://github.com/facebook/draft-js/issues/2093


### PR DESCRIPTION
日本語入力を行うと、変換が確定したタイミングでエディタ全体を再レンダリングしていた。`resolveComposition`に書かれたコメントには、行頭で変換が必要な入力が発生すると予期しないTextノードが生成されるのを阻止するためとある。

実際には、空行で日本語入力を行うと予期しないDOM構造となる問題が発生した。空行の構造を変更することで、入力済みの行と同じノードが生成されるようにした。