### PR TITLE
feat: 日本語入力で全体が再レンダリングされる回数を減らす

### DIFF
--- a/src/component/handlers/composition/DOMObserver.js
+++ b/src/component/handlers/composition/DOMObserver.js
@@ -23,7 +23,12 @@ const {Map} = Immutable;
 
 type MutationRecordT =
   | MutationRecord
-  | {|type: 'characterData', target: Node, removedNodes?: void|};
+  | {|
+      type: 'characterData',
+      target: Node,
+      addedNodes?: void,
+      removedNodes?: void,
+    |};
 
 // Heavily based on Prosemirror's DOMObserver https://github.com/ProseMirror/prosemirror-view/blob/master/src/domobserver.js
 
@@ -41,6 +46,7 @@ class DOMObserver {
   observer: ?MutationObserver;
   container: HTMLElement;
   mutations: Map<string, string>;
+  hasMutationAtLeafStart: boolean;
   onCharData: ?({
     target: EventTarget,
     type: string,
@@ -50,6 +56,7 @@ class DOMObserver {
   constructor(container: HTMLElement) {
     this.container = container;
     this.mutations = Map();
+    this.hasMutationAtLeafStart = false;
     const containerWindow = getWindowForNode(container);
     if (containerWindow.MutationObserver && !USE_CHAR_DATA) {
       this.observer = new containerWindow.MutationObserver(mutations =>
@@ -96,8 +103,10 @@ class DOMObserver {
       );
     }
     const mutations = this.mutations;
+    const hasMutationAtLeafStart = this.hasMutationAtLeafStart;
     this.mutations = Map();
-    return mutations;
+    this.hasMutationAtLeafStart = false;
+    return {mutations, hasMutationAtLeafStart};
   }
 
   registerMutations(mutations: Array<MutationRecord>): void {
@@ -107,7 +116,7 @@ class DOMObserver {
   }
 
   getMutationTextContent(mutation: MutationRecordT): ?string {
-    const {type, target, removedNodes} = mutation;
+    const {type, target, addedNodes, removedNodes} = mutation;
     if (type === 'characterData') {
       // When `textContent` is '', there is a race condition that makes
       // getting the offsetKey from the target not possible.
@@ -123,7 +132,11 @@ class DOMObserver {
         return target.textContent;
       }
     } else if (type === 'childList') {
-      if (removedNodes && removedNodes.length) {
+      if (addedNodes && addedNodes.length) {
+        // This mutation is creating a new node, meaning it's happening
+        // at the beginning of a leaf, so we must force a re-render.
+        this.hasMutationAtLeafStart = true;
+      } else if (removedNodes && removedNodes.length) {
         // `characterData` events won't happen or are ignored when
         // removing the last character of a leaf node, what happens
         // instead is a `childList` event with a `removedNodes` array.

--- a/src/component/handlers/composition/DraftEditorCompositionHandler.js
+++ b/src/component/handlers/composition/DraftEditorCompositionHandler.js
@@ -146,7 +146,9 @@ const DraftEditorCompositionHandler = {
     }
 
     const lastEditorState = editor._latestEditorState;
-    const mutations = nullthrows(domObserver).stopAndFlushMutations();
+    const observerMutations = nullthrows(domObserver).stopAndFlushMutations();
+    const {mutations, hasMutationAtLeafStart} = observerMutations;
+    let entityKey = null;
     domObserver = null;
     resolved = true;
 
@@ -196,10 +198,7 @@ const DraftEditorCompositionHandler = {
         isBackward: false,
       });
 
-      const entityKey = getEntityKeyForSelection(
-        contentState,
-        replacementRange,
-      );
+      entityKey = getEntityKeyForSelection(contentState, replacementRange);
       const currentStyle = contentState
         .getBlockForKey(blockKey)
         .getInlineStyleAt(start);
@@ -232,7 +231,8 @@ const DraftEditorCompositionHandler = {
     );
     const compositionEndSelectionState = documentSelection.selectionState;
 
-    editor.restoreEditorDOM();
+    const mustReset = hasMutationAtLeafStart || entityKey !== null;
+    if (mustReset) editor.restoreEditorDOM();
 
     // See:
     // - https://github.com/facebook/draft-js/issues/2093

--- a/src/component/handlers/composition/__tests__/DraftEditorCompostionHandler-test.js
+++ b/src/component/handlers/composition/__tests__/DraftEditorCompostionHandler-test.js
@@ -29,7 +29,7 @@ jest.mock('DOMObserver', () => {
   DOMObserver.prototype.start = jest.fn();
   DOMObserver.prototype.stopAndFlushMutations = jest
     .fn()
-    .mockReturnValue(Map({}));
+    .mockReturnValue({mutations: Map({})});
   return DOMObserver;
 });
 jest.mock('getContentEditableContainer');
@@ -119,9 +119,9 @@ test('Can handle a single mutation', () => {
   withGlobalGetSelectionAs({}, () => {
     editor._latestEditorState = getEditorState({blockkey0: ''});
     const mutations = Map({'blockkey0-0-0': '\u79c1'});
-    require('DOMObserver').prototype.stopAndFlushMutations.mockReturnValue(
+    require('DOMObserver').prototype.stopAndFlushMutations.mockReturnValue({
       mutations,
-    );
+    });
     // $FlowExpectedError[incompatible-use]
     // $FlowExpectedError[incompatible-call]
     compositionHandler.onCompositionStart(editor);
@@ -144,9 +144,9 @@ test('Can handle mutations in multiple blocks', () => {
       'blockkey0-0-0': 'reactjs',
       'blockkey1-0-0': 'draftjs',
     });
-    require('DOMObserver').prototype.stopAndFlushMutations.mockReturnValue(
+    require('DOMObserver').prototype.stopAndFlushMutations.mockReturnValue({
       mutations,
-    );
+    });
     // $FlowExpectedError[incompatible-use]
     // $FlowExpectedError[incompatible-call]
     compositionHandler.onCompositionStart(editor);
@@ -174,9 +174,9 @@ test('Can handle mutations in the same block in multiple leaf nodes', () => {
       [`${blockKey}-0-1`]: 'draftbb',
       [`${blockKey}-0-2`]: ' graphqlccc',
     });
-    require('DOMObserver').prototype.stopAndFlushMutations.mockReturnValue(
+    require('DOMObserver').prototype.stopAndFlushMutations.mockReturnValue({
       mutations,
-    );
+    });
     // $FlowExpectedError[incompatible-use]
     // $FlowExpectedError[incompatible-call]
     compositionHandler.onCompositionStart(editor);


### PR DESCRIPTION
#1 で実施した処置では日本語変換時のDOM再レンダリングを完全に除去することはできなかった。

そこで本体に寄せられていた https://github.com/facebook/draft-js/pull/2823 の変更を取り込み、再レンダリングの回数を削減する。この変更では、再レンダリングの処理を変換処理によって新しいtext nodeが作られたときに限定する。